### PR TITLE
Update Jekyll permalinks to match blogger URL format

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -180,7 +180,7 @@ sass:
 
 
 # Outputting
-permalink: /:categories/:title/
+permalink: :year/:month/:title.html
 paginate: 5 # amount of posts to show
 paginate_path: /page:num/
 timezone: # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones


### PR DESCRIPTION
Assists with #2, though we'll want to still do a check at the end.

According to the items in `_posts`, the permalink for the blogger URLs used to be `/year/month/title.html`.

For example, in `2005-08-05-voila-automatic-xml-comment-generation.html`, I saw the frontmatter of:

`blogger_orig_url: http://www.continuousimprover.com/2005/08/voila-automatic-xml-comment-generation.html`

By updating `_config.yml` to use `permalink: :year/:month/:title.html`, that the URL path for blogger will reflect the current URL structure and greatly reduce broken links.