### PR TITLE
Remove build warning about Github Auth

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ description              : "On an everlasting quest for better solutions"
 url                      : # the base hostname & protocol for your site e.g. "https://mmistakes.github.io"
 baseurl                  : # the subpath of your site, e.g. "/blog"
 repository               : dennisdoomen/dennisdoomen.github.io
+github                   : dennisdoomen/dennisdoomen.github.io
 teaser                   : # path of fallback teaser image, e.g. "/assets/images/500x300.png"
 # breadcrumbs            : false # true, false (default)
 words_per_minute         : 200


### PR DESCRIPTION
When building locally, I saw the warning:

> ![before](https://user-images.githubusercontent.com/2148318/37740795-65fa4b6c-2d35-11e8-8d81-96e1524b2daf.png)

After updating the `_config` to add a `github` value for the plugin to use, I was able to build without the warning:

> ![after](https://user-images.githubusercontent.com/2148318/37740830-8ef9a878-2d35-11e8-8e8d-f06ec1c3d570.png)
