### PR TITLE
Update 2018-07-25-dealing-with-non-transient-exceptions.md

### DIFF
--- a/_posts/2018-07-25-dealing-with-non-transient-exceptions.md
+++ b/_posts/2018-07-25-dealing-with-non-transient-exceptions.md
@@ -31,7 +31,7 @@ private async Task<ExceptionResolution> OnException(ProjectionException exceptio
         // entire batch of transactions. Maybe the exception resolves by itself. Otherwise just abort.
         if (attempts < 3)
         {
-            await Task.Delay(TimeSpan.FromSeconds(attempts ^ 2));
+            await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, attempts)));
 
             return ExceptionResolution.Retry;
         }


### PR DESCRIPTION
Code snippet fix, instead of delaying by 'attempts XOR 2' seconds, taking '2 to the power of attempts' seconds, so it's complying with the statement "(...) retrying with an exponential delay (...)".